### PR TITLE
Don't let orphan docker containers

### DIFF
--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -228,6 +228,7 @@ class Command(BaseCommand):
         # Initialize args list for docker
         args = [
             "/usr/bin/sudo", "/usr/bin/docker", "run",
+            "--rm",
             "-a", "stdin",
             "-a", "stdout",
             "-a", "stderr",


### PR DESCRIPTION
I just realized that running docker without the `--rm` flag leaves a lot of orphaned containers around.

Each time you call `docker run`, a new container is created and you either have to specify the `--rm` flag to automatically destroy it on exit, or do a manual cleanup from time to time.

Running `docker ps -a` shows you all the containers you own, including the orphaned ones. I ended up with more than 150 of them! :stuck_out_tongue: 

Good news is that we could run several dockerized thug instances in parallel, since each one of them is independent from the others!