### PR TITLE
Using docker image pdelsante/thug-dockerfile instead of pdelsante/thug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ehthumbs.db
 Icon?
 Thumbs.db
 .*.swp
+.ropeproject
 
 # Ignore Django secret_key
 rumal_back/secret_key.py

--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -20,6 +20,7 @@
 #           The Honeynet Project
 #
 import logging
+import netifaces
 import os
 import re
 import signal
@@ -233,9 +234,20 @@ class Command(BaseCommand):
             "-a", "stdout",
             "-a", "stderr",
             "-t",
-            "pdelsante/thug",
+            "pdelsante/thug-dockerfile",
             "/usr/bin/python", "/opt/thug/src/thug.py"
             ]
+
+        # Need to discover the host's docker0 IP address
+        # to be used to tell Thug where MongoDB resides
+        # FIXME: read this from a static config file before
+        # guessing.
+        try:
+            d0_address = netifaces.ifaddresses('docker0')[netifaces.AF_INET][0]['addr']
+            args.extend(['-D', '{}:27017'.format(d0_address)])
+        except:
+            logger.critical("Unable to get docker0 address, aborting")
+            raise
 
         # Base options
         if task.referer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django==1.7
 django-tastypie==0.12.1
 hexdump==3.2
+netifaces==0.10.4
 pymongo==3.0.3
 python-dateutil==2.4.2
 python-magic==0.4.6


### PR DESCRIPTION
Unfortunately we were using the wrong docker image.

I'm also excluding `vim`-generated `.ropeproject` files in `.gitignore`.